### PR TITLE
passaggio di clickhouse a 24.11 per risolver un bug

### DIFF
--- a/kafka-flink-llm-connector/docker-compose.yaml
+++ b/kafka-flink-llm-connector/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
   #     - 9000:9000 # Native
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.10
+    image: clickhouse/clickhouse-server:24.11
     hostname: clickhouse
     container_name: clickhouse
     ports:


### PR DESCRIPTION
24.10 spammava i log con errori in get_mempolicy 24.11 risolve